### PR TITLE
Updated awscli to use latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:trusty
 MAINTAINER Borja Burgos <borja@tutum.co>, Mia Iversen <mia@chillfox.com
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install groff awscli
+RUN apt-get update && apt-get install -y python-pip && pip install awscli
 
 ADD backup.sh /backup.sh
 ADD restore.sh /restore.sh


### PR DESCRIPTION
An updated awscli was necessary to support regions like eu-central-1 which use AWS4-HMAC-SHA256 Signature Version, see https://github.com/aws/aws-cli/issues/1011
