### PR TITLE
correct s3 cp cmd

### DIFF
--- a/restore.sh
+++ b/restore.sh
@@ -4,7 +4,7 @@
 : ${LAST_BACKUP:=$(aws s3 ls s3://$S3_BUCKET_NAME | awk -F " " '{print $4}' | grep ^$BACKUP_NAME | sort -r | head -n1)}
 
 # Download backup from S3
-aws s3 cp s3://$S3_BUCKET_NAME/$LAST_BACKUP $LAST_BACKUP
+aws s3 cp $LAST_BACKUP s3://$S3_BUCKET_NAME/$LAST_BACKUP
 
 # Extract backup
 tar xzf $LAST_BACKUP $RESTORE_TAR_OPTION


### PR DESCRIPTION
Corrected S3 `cp` cmd.

According to http://docs.aws.amazon.com/cli/latest/reference/s3/index.html

The command should be :

```
aws s3 cp $LAST_BACKUP s3://$S3_BUCKET_NAME/$LAST_BACKUP
```
