### PR TITLE
Remove tarball after upload

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -16,3 +16,6 @@ fi
 
 # Upload the backup to S3 with timestamp
 aws s3 --region $AWS_DEFAULT_REGION cp $tarball s3://$S3_BUCKET_NAME/$tarball
+
+# Clean up
+rm $tarball


### PR DESCRIPTION
Clean up after every run to avoid the container getting filled with old tar files over time. 

Otherwise there's a good chance for a full disk after a couple of runs, if the image is not being run with `--rm` or `autodestroy: always`.
