### PR TITLE
Fix problem with bucket existence verification

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -8,7 +8,7 @@ readonly tarball=$BACKUP_NAME$BACKUP_SUFFIX.tar.gz
 tar czf $tarball $BACKUP_TAR_OPTION $PATHS_TO_BACKUP
 
 # Create bucket, if it doesn't already exist
-BUCKET_EXIST=$(aws s3 ls | grep $S3_BUCKET_NAME | wc -l)
+BUCKET_EXIST=$(aws s3 ls | grep " ${S3_BUCKET_NAME}$" | wc -l)
 if [ $BUCKET_EXIST -eq 0 ];
 then
   aws s3 mb s3://$S3_BUCKET_NAME


### PR DESCRIPTION
Right now the bash script is using grep to find the presence of the bucket name anywhere in the response of `aws s3 ls`
The problem is that if you have something like this:

```
bash# aws s3 ls
2017-02-06 17:55:36 my-bucket-test
```

And now supose you want to run the script with a bucket named `my-bucket`, the `grep` will match the output and it will behave as if the bucket already exists